### PR TITLE
Possiblity to link the english / french button to same page

### DIFF
--- a/_i18n/fr/_posts/2023-11-14-Word_embedding.md
+++ b/_i18n/fr/_posts/2023-11-14-Word_embedding.md
@@ -9,6 +9,7 @@ excerpt : "Introduction au concept de word embedding <br>- Difficulté : débuta
 header:
    overlay_color: "#1C2A4D"
 author_profile: false
+translation: "en/Word_embedding_en/"
 sidebar:
     nav: sidebar-nlp
 classes: wide
@@ -23,7 +24,6 @@ italique      <i>deep learning</i>
 saut de ligne <br><br>
 lien externe  <a href="https://example.com">example</a>
 -->
-
 # Introduction
 
 <p style="text-align:justify;">

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -34,13 +34,25 @@
             </li>
           {%- endfor -%}
           
+   
+  
           {% if site.lang == "fr" %}
-            {% capture link1 %}{{ site.baseurl_root }}/en{% endcapture %}
+            {% if page.translation %}
+              {% capture link1 %}{{ site.baseurl_root }}/{{page.translation}}{% endcapture %} 
+            {% else %}
+              {% capture link1 %}{{ site.baseurl_root }}/en{% endcapture %}
+            {% endif %}
+
             <li class="masthead__menu-item"> 
               <a href="{{ link1 }}" > :gb: {% t global.english %}</a>
             </li>
           {% elsif site.lang == "en" %}
-            {% capture link2 %}{{ site.baseurl_root }}/../{% endcapture %}
+            {% if page.translation %}
+              {% capture link2 %}{{ site.baseurl_root }}/{{page.translation}}{% endcapture %} 
+            {% else %}
+               {% capture link2 %}{{ site.baseurl_root }}/../{% endcapture %}
+            {% endif %}
+          
             <li class="masthead__menu-item"> 
               <a href="{{ link2 }}" > :fr: {% t global.french %}</a>
             </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
     {% include_cached skip-links.html %}
-    {% include_cached masthead.html %}
+    {% include masthead.html %}
 
     <div class="initial-content">
       {{ content }}


### PR DESCRIPTION

## Lien traduction changeant suivant les pages

* Suppression du header en cache...  Qui m'a bien mis la misère. 
* Le lien vers la version fr/en peut être remplacé par une entrée `translation` dans le header du fichier. 
* C'est mis juste sur un fichier.